### PR TITLE
Add packaging script, bump plugin version, normalize file paths, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,24 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the terms of the MIT license.
+
+## Build and package
+
+You can build a distributable plugin ZIP locally with:
+
+```bash
+./gradlew buildPlugin
+```
+
+The artifact is generated under `build/distributions/*.zip`.
+
+Or use the helper script to optionally bump version and package in one step:
+
+```bash
+# package with current version
+./scripts/package-plugin.sh
+
+# bump version then package
+./scripts/package-plugin.sh 0.0.3
+```
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# CodeLink IDEA
+# CodeLink
 
 
-CodeLink IDEA is an IntelliJ IDEA plugin that allows developers to generate and navigate to code links. These code links are URLs that point to a specific line in a specific file in your project.
+CodeLink is an IntelliJ IDEA plugin that allows developers to generate and navigate to code links. These code links are URLs that point to a specific line in a specific file in your project.
 
 <!-- Plugin description -->
-CodeLink IDEA is an IntelliJ IDEA plugin that allows developers to generate and navigate to code links. These code links are URLs that point to a specific line in a specific file in your project.
+CodeLink is an IntelliJ IDEA plugin that allows developers to generate and navigate to code links. These code links are URLs that point to a specific line in a specific file in your project.
 <!-- Plugin description end -->
 
 ## Features
@@ -16,7 +16,7 @@ CodeLink IDEA is an IntelliJ IDEA plugin that allows developers to generate and 
 
 - Using the IDE built-in plugin system:
 
-  <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "CodeLink IDEA"</kbd> >
+  <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "CodeLink"</kbd> >
   <kbd>Install</kbd>
 
 - Manually:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.github.kentzhanggeek.codelinkidea
-pluginName = codelink_idea
+pluginName = CodeLink
 pluginRepositoryUrl = https://github.com/kentzhang-geek/codelink_idea
 # SemVer format -> https://semver.org
 pluginVersion = 0.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.kentzhanggeek.codelinkidea
 pluginName = codelink_idea
 pluginRepositoryUrl = https://github.com/kentzhang-geek/codelink_idea
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.2
+pluginVersion = 0.0.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 252

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+NEW_VERSION="${1:-}"
+
+if [[ -n "$NEW_VERSION" ]]; then
+  if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "Invalid version: $NEW_VERSION"
+    echo "Expected SemVer, e.g. 0.0.3 or 1.2.0-beta.1"
+    exit 1
+  fi
+
+  sed -i -E "s/^pluginVersion\s*=\s*.*/pluginVersion = ${NEW_VERSION}/" gradle.properties
+  echo "Updated pluginVersion to ${NEW_VERSION} in gradle.properties"
+fi
+
+echo "Packaging plugin ZIP..."
+./gradlew clean buildPlugin
+
+echo "Done. ZIP file(s):"
+ls -1 build/distributions/*.zip

--- a/src/main/kotlin/com/github/kentzhanggeek/codelinkidea/CodeLinkGenerate.kt
+++ b/src/main/kotlin/com/github/kentzhanggeek/codelinkidea/CodeLinkGenerate.kt
@@ -2,10 +2,8 @@ package com.github.kentzhanggeek.codelinkidea
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.fileEditor.FileEditorManager
 import java.awt.datatransfer.StringSelection
 
 class CodeLinkGenerate : AnAction() {
@@ -18,7 +16,7 @@ class CodeLinkGenerate : AnAction() {
                 val virtualFile = FileDocumentManager.getInstance().getFile(document)
                 if (virtualFile != null) {
                     val lineNumber = document.getLineNumber(editor.caretModel.offset) + 1
-                    val filePath = virtualFile.path
+                    val filePath = virtualFile.path.replace('\\', '/')
                     val url = "codelink://$filePath:$lineNumber"
 
                     // Copy the URL to the clipboard

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <id>com.github.kentzhanggeek.codelinkidea</id>
-    <name>codelink_idea</name>
+    <name>CodeLink</name>
     <vendor>kentzhang-geek</vendor>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
### Motivation

- Provide an easy local packaging workflow for the IntelliJ plugin and publish a small usability fix for generated code links.

### Description

- Add `scripts/package-plugin.sh` to optionally bump `pluginVersion` in `gradle.properties` and run `./gradlew clean buildPlugin` to produce distributable ZIP(s). 
- Bump `pluginVersion` from `0.0.2` to `0.0.3` in `gradle.properties`.
- Update `README.md` with a "Build and package" section that documents `./gradlew buildPlugin` and the new helper script usage.
- Normalize file paths in `CodeLinkGenerate.kt` by replacing backslashes with forward slashes when constructing `codelink://` URLs to ensure links are consistent across platforms.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ffa29704832a9f10996b9da6d1f8)